### PR TITLE
ADD: add info for accessing executables

### DIFF
--- a/docs/QuickStart.rst
+++ b/docs/QuickStart.rst
@@ -90,3 +90,26 @@ In order to build int2lm from the COSMO-ORG GitHub organization use the followin
 
   spack install int2lm@org_master%pgi pollen=False
 
+Accessing executables
+---------------------
+`As stated in the official spack documentation
+<https://spack.readthedocs.io/en/latest/workflows.html#find-and-run>`_,
+"The simplest way to run a Spack binary is to find it and run it" as
+it is build with `RPATH`. In most cases there is no need to adjust the
+environment. In order to find the directory where a package was
+installed, use the ``spack location`` command like this:
+
+.. code-block:: bash
+
+  spack location -i cosmo@dev-build%pgi cosmo_target=gpu +cppdycore
+
+or
+
+.. code-block:: bash
+
+  spack location -i int2lm@c2sm_master%pgi
+
+Note that the package location is also given on the last log line of
+the install process. For cosmo you'll find the executable, either
+``cosmo_cpu`` or ``cosmo_gpu``, under the ``bin`` subdirectory whereas the
+int2lm executable will be the ``bin`` *file* itself.

--- a/docs/SpackCommands.rst
+++ b/docs/SpackCommands.rst
@@ -169,6 +169,31 @@ Options (spack devbuildcosmo)
 * -t --test: run COSMO testsuite before installing
 * -c --clean_build: Clean build
 
+Spack location
+--------------
+Locate paths related to some spec. This command is mainly usefull to
+get the path where a package was installed (a long path with hashes)
+and access the coresponding binary (somewhere under that location).
+
+`As stated in the official spack documentation
+<https://spack.readthedocs.io/en/latest/workflows.html#find-and-run>`_,
+"The simplest way to run a Spack binary is to find it and run it" as
+it is build with `RPATH`. In most cases there is no need to adjust the
+environment.
+
+Other options can be used to retrieve other paths like the build
+directory or the path to the package definition (`see official spack
+documentation
+<https://spack.readthedocs.io/en/latest/command_index.html#spack-location>`_
+or ``spack location -h``)
+
+Usage (spack location)
+^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: bash
+
+  spack location -i <spec>
+
 Spack build-env
 ---------------
 Run a command in a specs install environment, or dump its environment to screen or file


### PR DESCRIPTION
Add doc to use the `spack location` command in the quickstart and
Spack commands sections.